### PR TITLE
Handle missing stdout match in run script

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -41,13 +41,13 @@ module.exports = () =>
 					]
 				}
 			},
-			{
-				method: 'local.set',
-				params:
-				{
-					url: '{{ input.stdout.match(/(http:\\S+)/gi)[0] }}'
-				}
-			},
+                        {
+                                method: 'local.set',
+                                params:
+                                {
+                                        url: '{{ (input.stdout.match(/(http:\\S+)/gi) || [])[0] }}'
+                                }
+                        },
 			{
 				method: 'browser.open',
 				params:


### PR DESCRIPTION
## Summary
- Avoid runtime errors when extracting the server URL in `run.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8971c7488332a708075f57e0284a